### PR TITLE
frontend README, .env.example, env & testing docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,41 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Financial Tracker — environment variables (backend)
+# Copy to `.env` (or set these in your runtime / CI secrets) and fill in values.
+# These map to ${...} placeholders in src/main/resources/application*.yml.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Spring profile: dev | prod
+SPRING_PROFILES_ACTIVE=prod
+
+# ── Database (PostgreSQL) ────────────────────────────────────────────────────
+DATABASE_URL=jdbc:postgresql://localhost:5432/financial_tracker
+DATABASE_USERNAME=financial
+DATABASE_PASSWORD=change-me
+
+# ── Security ─────────────────────────────────────────────────────────────────
+# Long random string used to sign JWTs.
+JWT_SECRET=change-me-to-a-long-random-secret
+
+# ── URLs / CORS ──────────────────────────────────────────────────────────────
+# Exact origin of the frontend (no trailing slash) allowed by CORS.
+CORS_ORIGIN=http://localhost:5173
+# Base URL of the frontend, used in emails (verification/reset links).
+FRONTEND_URL=http://localhost:5173
+
+# ── Mail (SMTP, e.g. Gmail app password) ─────────────────────────────────────
+MAIL_USERNAME=you@example.com
+MAIL_PASSWORD=app-password
+
+# ── OAuth2 (Google sign-in) ──────────────────────────────────────────────────
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+
+# ── AWS S3 (file storage) ────────────────────────────────────────────────────
+AWS_ACCESS_KEY_ID=your-access-key
+AWS_SECRET_ACCESS_KEY=your-secret-key
+AWS_REGION=eu-north-1
+AWS_S3_BUCKET=your-bucket-name
+
+# ── Redis (cache) ────────────────────────────────────────────────────────────
+REDIS_HOST=localhost
+REDIS_PORT=6379

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ Thumbs.db
 .env
 *.env
 .env.*
+!.env.example
 
 # Logs
 logs/

--- a/README.md
+++ b/README.md
@@ -192,12 +192,17 @@ Key entities managed by the application:
 
 ## Testing
 
-Run backend tests:
+**Backend** — JUnit 5, Mockito and Spring Boot Test. Integration tests use
+**Testcontainers** (spins up a real PostgreSQL in Docker), so Docker must be
+running. Service-layer coverage spans budgets, categories, currency, goals,
+recurring transactions, transactions and users.
+
 ```bash
-./mvnw test
+./mvnw test     # runs the full suite
 ```
 
-Run frontend linting:
+**Frontend** — no unit-test framework is configured yet; only ESLint:
+
 ```bash
 cd frontend
 npm run lint
@@ -258,16 +263,23 @@ Workflow: `.github/workflows/deploy.yml`
 
 ### Environment Variables
 
-Configure these environment variables for production:
-- `SPRING_PROFILES_ACTIVE` - Active Spring profile
-- `SPRING_DATASOURCE_URL` - PostgreSQL connection URL
-- `SPRING_DATASOURCE_USERNAME` - Database username
-- `SPRING_DATASOURCE_PASSWORD` - Database password
+See [`.env.example`](.env.example) for a copy-paste template. Required/optional
+variables (set as environment variables or via secrets in CI):
+
+- `SPRING_PROFILES_ACTIVE` - Active Spring profile (`dev` | `prod`)
+- `DATABASE_URL` / `DATABASE_USERNAME` / `DATABASE_PASSWORD` - PostgreSQL connection
+  (the deploy pipeline passes the equivalent `SPRING_DATASOURCE_*` variables)
 - `JWT_SECRET` - Secret key for JWT token signing
-- `CORS_ORIGIN` - Frontend origin for CORS
-- `FRONTEND_URL` - Frontend base URL
-- `MAIL_USERNAME` - Email account username
-- `MAIL_PASSWORD` - Email account password
+- `CORS_ORIGIN` - Frontend origin allowed by CORS (exact, no trailing slash)
+- `FRONTEND_URL` - Frontend base URL (used in email links)
+- `MAIL_USERNAME` / `MAIL_PASSWORD` - SMTP credentials
+- `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` - Google OAuth2 sign-in
+- `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` / `AWS_S3_BUCKET` -
+  S3 file storage (S3 is enabled only when an access key is provided)
+- `REDIS_HOST` / `REDIS_PORT` - Redis cache
+
+Frontend build var (set at build time): `VITE_API_URL` - API base URL
+(e.g. `https://your-domain/api/v1`).
 
 ## Security Features
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,12 +1,76 @@
-# React + Vite
+# Financial Tracker — Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Single-page application for the Financial Tracker, built with **React 19** and **Vite**.
+Talks to the Spring Boot backend over a REST API (`/api/v1`) and a STOMP/SockJS
+WebSocket for real-time notifications.
 
-Currently, two official plugins are available:
+## Tech stack
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- **React 19** + **Vite 7** (HMR, fast builds)
+- **React Router 7** — client-side routing
+- **TanStack Query (React Query) 5** — server state, caching, refetching
+- **axios** — HTTP client (JWT attached via interceptor)
+- **Chart.js** + **react-chartjs-2** — analytics charts
+- **i18next / react-i18next** — internationalization (EN / UA)
+- **@stomp/stompjs** + **sockjs-client** — WebSocket notifications
+- **lucide-react** + **@heroicons/react** — icons
+- **sonner** — toast notifications
+- **Styling:** inline styles driven by a central theme (`src/styles/theme.js`)
+  with light/dark **emerald** themes via a `data-theme` attribute. **No CSS
+  framework** (no Tailwind) — global resets/tokens live in `src/index.css`.
 
-## Expanding the ESLint configuration
+## Getting started
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+```bash
+npm install
+npm run dev        # http://localhost:5173
+```
+
+The dev server proxies `/api` and `/ws` to the backend (see `vite.config.js`).
+By default the backend is expected on `http://localhost:8080`.
+
+### Scripts
+
+| Command           | Description                              |
+|-------------------|------------------------------------------|
+| `npm run dev`     | Start the Vite dev server (HMR)          |
+| `npm run build`   | Production build → `dist/`               |
+| `npm run preview` | Serve the production build locally       |
+| `npm run lint`    | Run ESLint                               |
+
+## Configuration
+
+The API base URL is read from `VITE_API_URL` (falls back to
+`http://localhost:8080/api/v1`):
+
+- **Dev:** set `VITE_API_URL=/api/v1` (in `.env.development`) so requests go
+  through the Vite proxy and avoid CORS.
+- **Prod:** the CI build sets `VITE_API_URL` to the deployed API origin
+  (e.g. `https://financial-trackersite.site/api/v1`).
+
+## Project structure
+
+```
+src/
+  components/   reusable UI (cards, charts, layout, modals, auth, ...)
+  pages/        routed pages (Dashboard, Transactions, Budgets, Goals, ...)
+  contexts/     Auth, Theme, Language, Currency providers
+  hooks/        useAuth, useTheme, useCurrency, useWebSocketNotifications, ...
+  services/     axios API clients per domain
+  styles/       theme tokens (light/dark)
+  locales/      en / uk translation JSON
+  i18n/         i18next setup
+```
+
+## Theming
+
+Theme tokens are defined in `src/styles/theme.js` and consumed through the
+`useThemedStyles(getStyles)` hook. Components define a
+`getStyles(theme, { isMobile, isTablet })` function, so changing a token
+restyles the whole app. The active theme is persisted in `localStorage` and
+reflected on `<html data-theme="light|dark">`.
+
+## Testing
+
+No frontend test framework is configured yet — only ESLint (`npm run lint`).
+Backend tests live in the repository root (`mvn test`).


### PR DESCRIPTION
Documentation-only cleanup

Rewrite frontend/README.md to reflect the real stack (React 19, Vite, React Query, React Router, Chart.js, i18next, STOMP/SockJS) explicitly notes NO Tailwind.
Add .env.example with all required backend env vars (DB, JWT, CORS, mail, Google OAuth2, AWS S3, Redis) + a .gitignore exception so the template stays tracked.
Expand main README: complete env-var list (adds GOOGLE_*, AWS_*, REDIS_*, VITE_API_URL) and a more accurate Testing section (JUnit + Testcontainers; frontend has lint only).